### PR TITLE
fix: compatibility with current oakvar, accept additional parameters in run()

### DIFF
--- a/superhumanreporter.py
+++ b/superhumanreporter.py
@@ -17,7 +17,7 @@ class Reporter(CravatReport):
         self.savepath = kwargs["savepath"]
 
 
-    async def run(self):
+    async def run(self, *args, **kwargs):
         self.setup()
         self.write_data()
         self.end()


### PR DESCRIPTION
fixes the following error:
```
2025/04/02 07:41:16 oakvar               starting superhumanreporter...
2025/04/02 07:41:16 oakvar               Traceback (most recent call last):
  File "/.../oakvar/.venv/lib/python3.13/site-packages/oakvar/lib/base/runner.py", line 367, in main
    await self.process_file(run_no)
  File "/.../oakvar/.venv/lib/python3.13/site-packages/oakvar/lib/base/runner.py", line 334, in process_file
    await self.do_step_reporter(run_no)
  File "/.../oakvar/.venv/lib/python3.13/site-packages/oakvar/lib/base/runner.py", line 2196, in do_step_reporter
    self.report_response = await self.log_time_of_func(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.run_reporter, run_no, work=f"{step} step"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/.../oakvar/.venv/lib/python3.13/site-packages/oakvar/lib/base/runner.py", line 2210, in log_time_of_func
    ret = await func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../oakvar/.venv/lib/python3.13/site-packages/oakvar/lib/base/runner.py", line 2099, in run_reporter
    response_t = await self.log_time_of_func(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        reporter.run, head_n=head_n, work=module_name
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/.../oakvar/.venv/lib/python3.13/site-packages/oakvar/lib/base/runner.py", line 2210, in log_time_of_func
    ret = await func(*args, **kwargs)
                ~~~~^^^^^^^^^^^^^^^^^
TypeError: Reporter.run() got an unexpected keyword argument 'head_n'
2025/04/02 07:41:16 oakvar               Error occurred:
2025/04/02 07:41:16 oakvar               Reporter.run() got an unexpected keyword argument 'head_n'
```